### PR TITLE
image

### DIFF
--- a/src/modules/my-tickets/components/ticket-card.tsx
+++ b/src/modules/my-tickets/components/ticket-card.tsx
@@ -40,8 +40,8 @@ export const TicketCard = ({ ticket }: TicketCardProps) => {
     eventData = ticket.eventId as PopulatedEvent;
     isExpired = new Date(eventData.date) < new Date();
     eventImage =
-      eventData.images?.[0] ||
-      eventData.culturalPlaceId?.images?.[0] ||
+      eventData.image ||
+      eventData.culturalPlaceId?.image ||
       '/placeholder-image.jpg';
   }
 

--- a/src/modules/my-tickets/my-tickets.api.ts
+++ b/src/modules/my-tickets/my-tickets.api.ts
@@ -10,9 +10,9 @@ export interface PopulatedEvent {
     _id: string;
     name: string;
     address: string;
-    images: string[];
+    image: string;
   };
-  images: string[];
+  image: string;
 }
 
 export interface Ticket {


### PR DESCRIPTION
habia hecho un workarround falopa en el back para poder soportar que images sea una lista, pero al final no era necesario, porque para crear se pasa un solo link, y la creacion de eventos no maneja images.

Con esto puedo dejar mas limpio el back