### PR TITLE
typo recomendation

### DIFF
--- a/src/modules/recomendations/components/recommendation-card.tsx
+++ b/src/modules/recomendations/components/recommendation-card.tsx
@@ -92,14 +92,14 @@ export const RecommendationCard = ({
         <Button
           size="sm"
           variant="outline"
-          onClick={() => navigate(`/eventos/${recommendation.id}`)}
+          onClick={() => navigate(`/evento/${recommendation.id}`)}
         >
           Ver detalles
         </Button>
         <Button
           size="sm"
           colorScheme="teal"
-          onClick={() => navigate(`/eventos/${recommendation.id}/comprar`)}
+          onClick={() => navigate(`/evento/${recommendation.id}`)}
         >
           Comprar entrada
         </Button>


### PR DESCRIPTION
no existe /eventos/id , sino /evento/id

y el /comprar es lo mismo que ir a ver el evento, lo quito.

